### PR TITLE
Fixes for non-legacy data in scRNAseq

### DIFF
--- a/inst/book/cell-cycle.Rmd
+++ b/inst/book/cell-cycle.Rmd
@@ -318,7 +318,7 @@ library(scRNAseq)
 sce.leng <- LengESCData(ensembl=TRUE)
 
 # Performing a default analysis without any removal:
-sce.leng <- logNormCounts(sce.leng, assay.type="normcounts")
+sce.leng <- logNormCounts(sce.leng, assay.type="normalized")
 dec.leng <- modelGeneVar(sce.leng)
 top.hvgs <- getTopHVGs(dec.leng, n=1000)
 sce.leng <- runPCA(sce.leng, subset_row=top.hvgs)

--- a/inst/book/droplet-processing.Rmd
+++ b/inst/book/droplet-processing.Rmd
@@ -259,7 +259,7 @@ library(scRNAseq)
 hto.sce <- StoeckiusHashingData(type="mixed")
 hto.sce # The full dataset
 altExp(hto.sce) # Contains the HTO counts
-counts(altExp(hto.sce))[,1:3] # Preview of the count profiles
+assay(altExp(hto.sce), "counts")[,1:3] # Preview of the count profiles
 ```
 
 ### Cell calling options
@@ -291,7 +291,7 @@ set.seed(10010)
 
 # Setting lower= for correct knee point detection, 
 # as the coverage in this dataset is particularly low.
-e.out.hto <- emptyDrops(counts(altExp(hto.sce)), by.rank=12000, lower=10)
+e.out.hto <- emptyDrops(assay(altExp(hto.sce), "counts"), by.rank=12000, lower=10)
 summary(is.cell.hto <- e.out.hto$FDR <= 0.001)
 
 par(mfrow=c(1,2))
@@ -330,7 +330,7 @@ This reports the likely sample of origin for each library based on its most abun
 For quality control, it returns the log-fold change between the first and second-most abundant HTOs in each barcode libary (Figure \@ref(fig:hto-1to2-hist)), allowing us to quantify the certainty of each assignment.
 
 ```{r hto-1to2-hist, fig.cap="Distribution of log-fold changes from the first to second-most abundant HTO in each cell."}
-hto.mat <- counts(altExp(hto.sce))[,which(is.cell)]
+hto.mat <- assay(altExp(hto.sce), "counts")[,which(is.cell)]
 hash.stats <- hashedDrops(hto.mat)
 hist(hash.stats$LogFC, xlab="Log fold-change from best to second HTO", main="")
 ```
@@ -372,7 +372,7 @@ e.g., if there are too few cells in the lower mode for accurate estimation of a 
 ```{r hto-ambient2, fig.cap="Proportion of each HTO in the ambient solution for the cell line mixture data, estimated using the bimodal method in `hashedDrops()` or by computing the average abundance across all empty droplets (where the empty state is defined by using `emptyDrops()` on either the genes or the HTO matrix)."}
 estimates <- rbind(
     `Bimodal`=proportions(metadata(hash.stats)$ambient),
-    `Empty (genes)`=proportions(rowSums(counts(altExp(hto.sce))[,is.na(e.out.gene$FDR)])),
+    `Empty (genes)`=proportions(rowSums(assay(altExp(hto.sce), "counts")[,is.na(e.out.gene$FDR)])),
     `Empty (HTO)`=metadata(e.out.hto)$ambient[,1]
 )
 

--- a/inst/book/more-hvgs.Rmd
+++ b/inst/book/more-hvgs.Rmd
@@ -34,7 +34,7 @@ extractFromPackage("segerstolpe-pancreas.Rmd", package="OSCA.workflows",
 
 ```{r trend-plot-seger-noweight, fig.cap="Variance in the Segerstolpe pancreas data set as a function of the mean. Each point represents a gene while the lines represent the trend fitted to all genes with default parameters (blue) or without weights (red)."}
 library(scran)
-sce.seger <- sce.seger[,sce.seger$Donor=="HP1507101"]
+sce.seger <- sce.seger[,sce.seger$Donor=="H4"]
 dec.default <- modelGeneVar(sce.seger)
 dec.noweight <- modelGeneVar(sce.seger, density.weights=FALSE)
 

--- a/inst/book/protein-abundance.Rmd
+++ b/inst/book/protein-abundance.Rmd
@@ -340,7 +340,8 @@ This can be easily achieved by running `runPCA()` without passing in a vector of
 ```{r}
 library(scRNAseq)
 sce.kotliarov <- KotliarovPBMCData()
-adt.kotliarov <- altExp(sce.kotliarov)
+# More convenient more subsequent steps have data as SCE than as an SE.
+adt.kotliarov <- as(altExp(sce.kotliarov), "SingleCellExperiment")
 adt.kotliarov
 
 # QC.
@@ -666,7 +667,7 @@ This yields a number of gene/protein pairs with strong correlations - many of wh
 # Using multiple core for speed.
 library(BiocParallel)
 blocked.correlations <- computeCorrelations(sce.main, altExp(sce.main), 
-    block=clusters.adt, BPPARAM=MulticoreParam(4), use.names=c("Symbol", NA))
+    block=clusters.adt, BPPARAM=SerialParam(), use.names=c("Symbol", NA))
 
 blocked.correlations[order(blocked.correlations$p.value),]
 
@@ -690,7 +691,7 @@ The example below will find the top 10 genes in the RNA data that are correlated
 ```{r}
 set.seed(100) # For the IRLBA step.
 top.correlations <- findTopCorrelations(x=altExp(sce.main), y=sce.main, 
-    number=10, use.names=c(NA, "Symbol"), BPPARAM=MulticoreParam(4))
+    number=10, use.names=c(NA, "Symbol"), BPPARAM=SerialParam())
 top.correlations$positive
 ```
 


### PR DESCRIPTION
**scRNAseq** recently introduced new ('non-legacy') versions of dataset.
This PR migrates to these non-legacy datasets and updates the relevant chapters.
I've filed a few issues at **scRNAseq** to discuss these changes.

@lgeistlinger the book still fails to build due to unrelated issues with the `trajectory.Rmd` chapter.
Can you please take a look at that because I've been working on getting all the other books back in action for BioC 3.19. 